### PR TITLE
Add query to get all items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'rails', '~> 6.0.0'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'factory_bot_rails'
+  gem "faker"
   gem 'rspec-rails', '~> 3.8'
 end
 
@@ -21,6 +23,10 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+end
+
+group :test do
+  gem "shoulda-matchers"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,13 @@ GEM
     crass (1.0.5)
     diff-lcs (1.3)
     erubi (1.9.0)
+    factory_bot (5.1.1)
+      activesupport (>= 4.2.0)
+    factory_bot_rails (5.1.1)
+      factory_bot (~> 5.1.0)
+      railties (>= 4.2.0)
+    faker (2.6.0)
+      i18n (>= 1.6, < 1.8)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -143,6 +150,8 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.0)
     ruby_dep (1.5.0)
+    shoulda-matchers (4.0.1)
+      activesupport (>= 4.2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -169,12 +178,15 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  factory_bot_rails
+  faker
   graphql
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 3.11)
   rails (~> 6.0.0)
   rspec-rails (~> 3.8)
+  shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,9 +1,5 @@
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
-
-    def resolve_field(obj, args, ctx)
-      resolve(obj, args, ctx)
-    end
   end
 end

--- a/app/graphql/types/base_resolver.rb
+++ b/app/graphql/types/base_resolver.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseResolver < GraphQL::Schema::Resolver
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,13 +1,5 @@
 module Types
   class QueryType < Types::BaseObject
-    # Add root-level fields here.
-    # They will be entry points for queries on your schema.
-
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
-    end
+    field :items, resolver: ItemsQuery
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,3 @@
+class Item < ApplicationRecord
+  validates :name, presence: true
+end

--- a/app/operations/items_query.rb
+++ b/app/operations/items_query.rb
@@ -1,0 +1,8 @@
+class ItemsQuery < Types::BaseResolver
+  description "Gets all the items"
+  type Outputs::ItemType.connection_type, null: false
+
+  def resolve
+    Item.all
+  end
+end

--- a/app/operations/outputs/item_type.rb
+++ b/app/operations/outputs/item_type.rb
@@ -1,0 +1,6 @@
+module Outputs
+  class ItemType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+  end
+end

--- a/db/migrate/20191020021520_create_items.rb
+++ b/db/migrate/20191020021520_create_items.rb
@@ -1,0 +1,9 @@
+class CreateItems < ActiveRecord::Migration[6.0]
+  def change
+    create_table :items do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_10_20_021520) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "items", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item do
+    name { Faker::Commerce.product_name }
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Item, type: :model do
+  context "validations" do
+    it "is valid with valid attributes" do
+      expect(build(:item)).to be_valid
+    end
+
+    it { should validate_presence_of(:name) }
+  end
+end

--- a/spec/operations/items_query_spec.rb
+++ b/spec/operations/items_query_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Items Query API", :graphql do
+  describe "items" do
+    let(:query) do
+      <<-'GRAPHQL'
+        query {
+          items {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "returns a list of items" do
+      item = create(:item)
+
+      result = execute query
+
+      items_result = result[:data][:items][:edges].pluck(:node)
+      expect(items_result).to include(id: item.id.to_s)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -60,4 +60,14 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  Shoulda::Matchers.configure do |matchers|
+    matchers.integrate do |with|
+      with.test_framework :rspec
+      with.library :active_model
+      with.library :active_record
+    end
+  end
+
+  config.include GraphQLHelpers, :graphql
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/graphql_helpers.rb
+++ b/spec/support/graphql_helpers.rb
@@ -1,0 +1,9 @@
+module GraphQLHelpers
+  def execute(query, context: {}, variables: {})
+    VendingApiSchema.execute(
+      query,
+      context: context,
+      variables: variables.with_indifferent_access
+    ).with_indifferent_access
+  end
+end


### PR DESCRIPTION
Because:
- The vending machine will need to return a list of all the items it contains
- This was a good starting point

This commit:
- adds an `Items` field to our graphql schema
- creates an `Item` model with a name attribute
- add a graphql helper for executing a query
- installs shoulda-matchers gem
- intstalls factory bot
- remove the `resolve_field` method from the `BaseField` graphql object. It seems to be related to some bug with the `graphql-ruby` gem. Not yet an issue created about it but the creator acknowledged it in the slack channel.