### PR TITLE
Add mutation to create an item

### DIFF
--- a/app/graphql/resolvers/error.rb
+++ b/app/graphql/resolvers/error.rb
@@ -1,0 +1,22 @@
+module Resolvers
+  class Error < Types::BaseResolver
+    graphql_name "Error"
+    type [Types::ErrorType], null: false
+    description "Validation error"
+
+    def resolve
+      map_errors(object[:errors])
+    end
+
+    private
+
+    def map_errors(errors)
+      case errors
+      when ActiveModel::Errors
+        errors.map { |field, message| {field: field, message: message} }
+      else
+        errors.map { |error| {field: :base, message: error} }
+      end
+    end
+  end
+end

--- a/app/graphql/types/base_mutation.rb
+++ b/app/graphql/types/base_mutation.rb
@@ -1,0 +1,7 @@
+module Types
+  class BaseMutation < GraphQL::Schema::RelayClassicMutation
+    def self.graphql_name
+      super.chomp("Mutation")
+    end
+  end
+end

--- a/app/graphql/types/error_type.rb
+++ b/app/graphql/types/error_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class ErrorType < Types::BaseObject
+    field :field, String, "The field the error relates to", null: false
+    field :message, String, "The error message", null: false
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,10 +1,5 @@
 module Types
   class MutationType < Types::BaseObject
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World"
-    end
+    field :create_item, resolver: CreateItemMutation
   end
 end

--- a/app/operations/create_item_mutation.rb
+++ b/app/operations/create_item_mutation.rb
@@ -1,0 +1,18 @@
+class CreateItemMutation < Types::BaseMutation
+  description "Create a new item"
+
+  argument :name, String, required: true
+
+  field :item, Outputs::ItemType, null: true
+  field :errors, resolver: Resolvers::Error
+
+  def resolve(input)
+    item = Item.new(input.to_h)
+
+    if item.save
+      {item: item, errors: []}
+    else
+      {item: nil, errors: result.errors}
+    end
+  end
+end

--- a/spec/operations/create_item_mutation_spec.rb
+++ b/spec/operations/create_item_mutation_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "Create Item Mutation API", :graphql do
+  describe "createItem" do
+    let(:query) do
+      <<~'GRAPHQL'
+        mutation($input: CreateItemInput!) {
+          createItem(input: $input) {
+            item {
+              name
+            }
+          }
+        }
+      GRAPHQL
+    end
+
+    it "makes a new item" do
+      result = execute query, variables: {
+        input: {
+          name: "Snickers",
+        },
+      }
+
+      item_result = result[:data][:createItem][:item]
+      expect(item_result[:name]).to eq("Snickers")
+      expect(Item.first.name).to eq("Snickers")
+    end
+  end
+end


### PR DESCRIPTION
Because:
- The vending machine needs items to sell
- This is how new items will get added to the machine

This commit:
- adds first mutation `createItem`
- adds an error resolver that puts returned errors in a consistent format.
- adds a base mutation class that removes “Mutation” from the name of the mutation. `createItem` instead of `createItemMutation`. I prefer it this way. It also matches Githubs graphql api.