### PR TITLE
Add mutation to insert money

### DIFF
--- a/app/graphql/types/money.rb
+++ b/app/graphql/types/money.rb
@@ -1,0 +1,8 @@
+module Types
+  class Money < Types::BaseEnum
+    graphql_name "MoneyType"
+    description "A representation of currency"
+
+    value "QUARTER", value: Quarter
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_item, resolver: CreateItemMutation
+    field :insert_money, resolver: InsertMoneyMutation
   end
 end

--- a/app/models/money.rb
+++ b/app/models/money.rb
@@ -1,0 +1,3 @@
+class Money < ApplicationRecord
+  validates :type, presence: true
+end

--- a/app/models/quarter.rb
+++ b/app/models/quarter.rb
@@ -1,0 +1,2 @@
+class Quarter < Money
+end

--- a/app/operations/insert_money_mutation.rb
+++ b/app/operations/insert_money_mutation.rb
@@ -1,0 +1,11 @@
+class InsertMoneyMutation < Types::BaseMutation
+  description "Creates the specified money"
+
+  argument :money, Types::Money, required: true
+
+  field :success, Boolean, null: true
+
+  def resolve(money:)
+    { success: money.create }
+  end
+end

--- a/db/migrate/20191020193341_create_money.rb
+++ b/db/migrate/20191020193341_create_money.rb
@@ -1,0 +1,9 @@
+class CreateMoney < ActiveRecord::Migration[6.0]
+  def change
+    create_table :money do |t|
+      t.string :type, null: false
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_20_021520) do
+ActiveRecord::Schema.define(version: 2019_10_20_193341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "items", force: :cascade do |t|
     t.string "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "money", force: :cascade do |t|
+    t.string "type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/money.rb
+++ b/spec/factories/money.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :money do
+  end
+
+  factory :quarter, parent: :money, class: Quarter
+end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Money, type: :model do
+  context "validations" do
+    it "is valid with valid attributes" do
+      expect(build(:quarter)).to be_valid
+    end
+
+    it { should validate_presence_of(:type) }
+  end
+end

--- a/spec/operations/insert_money_mutation_spec.rb
+++ b/spec/operations/insert_money_mutation_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Insert Money Mutation API", :graphql do
+  describe "insertMoney" do
+    let(:query) do
+      <<~'GRAPHQL'
+        mutation($input: InsertMoneyInput!) {
+          insertMoney(input: $input) {
+            success
+          }
+        }
+      GRAPHQL
+    end
+
+    it "creates a quarter" do
+      result = execute query, variables: {
+        input: {
+          money: "QUARTER"
+        },
+      }
+
+      success_result = result[:data][:insertMoney][:success]
+      expect(success_result).to eq(true)
+      expect(Quarter.count).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Because:
- Users expect to interact with this application by inserting money before they purchase an item

This commit:
- Adds a new active record: `Money`. For now this will be represented by just `Quarter` but more types to come
- Populates a graphql enum based on the different money models that we have
- A new mutation that takes a money enum and persists the associated model