### PR TITLE
Add a mutation to refund all pending money

### DIFF
--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,5 +2,6 @@ module Types
   class MutationType < Types::BaseObject
     field :create_item, resolver: CreateItemMutation
     field :insert_money, resolver: InsertMoneyMutation
+    field :refund_money, resolver: RefundMoneyMutation
   end
 end

--- a/app/models/money.rb
+++ b/app/models/money.rb
@@ -6,4 +6,8 @@ class Money < ApplicationRecord
   def self.pending_balance
     pending.sum { |coin| coin.class::VALUE }
   end
+
+  def self.refund
+    pending.destroy_all
+  end
 end

--- a/app/operations/refund_money_mutation.rb
+++ b/app/operations/refund_money_mutation.rb
@@ -1,0 +1,11 @@
+class RefundMoneyMutation < Types::BaseMutation
+  description "Removes all the pending money from the machine"
+
+  field :money, [Types::Money], null: true
+
+  def resolve
+    refund = Money.refund
+
+    { money: refund.map(&:class) }
+  end
+end

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -32,4 +32,16 @@ RSpec.describe Money, type: :model do
       expect(result).to eq(50)
     end
   end
+
+  describe ".refund" do
+    it "deletes and returns all of the pending money" do
+      first_pending_money = create(:quarter, :pending)
+      second_pending_money = create(:quarter, :pending)
+      not_pending_money = create(:quarter, :not_pending)
+
+      result = described_class.refund
+
+      expect(result).to eq([first_pending_money, second_pending_money])
+    end
+  end
 end

--- a/spec/operations/refund_money_mutation_spec.rb
+++ b/spec/operations/refund_money_mutation_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "Refund Money Mutation API", :graphql do
+  describe "refundMoney" do
+    let(:query) do
+      <<~'GRAPHQL'
+        mutation {
+          refundMoney(input: {}) {
+            money
+          }
+        }
+      GRAPHQL
+    end
+
+    it "removes all of the pending money from the machine" do
+      create_list(:quarter, 2, :pending)
+
+      result = execute query
+
+      refund_result = result[:data][:refundMoney]
+      expect(refund_result[:money]).to eq(["QUARTER", "QUARTER"])
+      expect(Quarter.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Because:
- This should mimic a real vending machine. The user can hit the refund button and get all the money back that hasn’t been spent

This commit:
- Adds a new mutation that returns an array of money enums representing the money that was refunded.