### PR TITLE
Add mutation for purchasing an item

### DIFF
--- a/app/graphql/types/money.rb
+++ b/app/graphql/types/money.rb
@@ -4,5 +4,7 @@ module Types
     description "A representation of currency"
 
     value "QUARTER", value: Quarter
+    value "DIME", value: Dime
+    value "NICKEL", value: Nickel
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -3,5 +3,6 @@ module Types
     field :create_item, resolver: CreateItemMutation
     field :insert_money, resolver: InsertMoneyMutation
     field :refund_money, resolver: RefundMoneyMutation
+    field :purchase_item, resolver: PurchaseItemMutation
   end
 end

--- a/app/models/dime.rb
+++ b/app/models/dime.rb
@@ -1,0 +1,3 @@
+class Dime < Money
+  VALUE = 10
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,4 @@
 class Item < ApplicationRecord
   validates :name, presence: true
+  validates :cost, presence: true, numericality: {greater_than: 0, only_integer: true}
 end

--- a/app/models/make_change.rb
+++ b/app/models/make_change.rb
@@ -1,0 +1,33 @@
+class MakeChange
+  def initialize(due:, available_money:)
+    @due = due
+    @available_money = available_money
+  end
+
+  def call
+    change = get_change
+    if change.sum { |money| money.value } == due
+      Result.success(change: change)
+    else
+      Result.failure("Could not make change")
+    end
+  end
+
+  private
+
+  attr_reader :due, :available_money
+
+  def get_change
+    result = money_sorted_big_to_little.reduce(remaining: due, change: []) { |acc, money|
+      next(acc) unless (acc[:remaining] / money.value).positive?
+
+      acc[:remaining] -= money.value
+      acc[:change] << money
+      acc
+    }[:change]
+  end
+
+  def money_sorted_big_to_little
+    available_money.sort { |a, b| b.value <=> a.value }
+  end
+end

--- a/app/models/money.rb
+++ b/app/models/money.rb
@@ -4,10 +4,14 @@ class Money < ApplicationRecord
   scope :pending, -> { where(pending: true) }
 
   def self.pending_balance
-    pending.sum { |coin| coin.class::VALUE }
+    pending.sum { |coin| coin.value }
   end
 
   def self.refund
     pending.destroy_all
+  end
+
+  def value
+    self.class::VALUE
   end
 end

--- a/app/models/nickel.rb
+++ b/app/models/nickel.rb
@@ -1,0 +1,3 @@
+class Nickel < Money
+  VALUE = 5
+end

--- a/app/models/purchase_item.rb
+++ b/app/models/purchase_item.rb
@@ -1,0 +1,35 @@
+class PurchaseItem
+  def initialize(item)
+    @item = item
+  end
+
+  def call
+    return Result.failure("Not enough money provided") if !afford?
+
+    result = MakeChange.new(
+      due: pending_balance - item.cost,
+      available_money: Money.all
+    ).call
+
+    if result.success?
+      Result.success(
+        item: item.delete,
+        change: result.change.map { |change| change.destroy }
+      )
+    else
+      result
+    end
+  end
+
+  private
+
+  attr_reader :item
+
+  def afford?
+    pending_balance >= item.cost
+  end
+
+  def pending_balance
+    @pending_balance ||= Money.pending_balance
+  end
+end

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,0 +1,16 @@
+class Result
+  def self.success(fields = {})
+    result = create_result(fields.keys)
+    result.new(success?: true, errors: [], **fields)
+  end
+
+  def self.failure(errors, fields = {})
+    result = create_result(fields.keys)
+    errors = Array.wrap(errors) unless errors.is_a?(Enumerable)
+    result.new(success?: false, errors: errors, **fields)
+  end
+
+  private_class_method def self.create_result(fields)
+    Struct.new(:success?, *fields, :errors, keyword_init: true)
+  end
+end

--- a/app/operations/create_item_mutation.rb
+++ b/app/operations/create_item_mutation.rb
@@ -2,6 +2,7 @@ class CreateItemMutation < Types::BaseMutation
   description "Create a new item"
 
   argument :name, String, required: true
+  argument :cost, Integer, required: true
 
   field :item, Outputs::ItemType, null: true
   field :errors, resolver: Resolvers::Error

--- a/app/operations/purchase_item_mutation.rb
+++ b/app/operations/purchase_item_mutation.rb
@@ -1,0 +1,20 @@
+class PurchaseItemMutation < Types::BaseMutation
+  description "Purchase an new item using any pending money and return the change"
+
+  argument :item_id, ID, required: true
+
+  field :item, Outputs::ItemType, null: true
+  field :change, [Types::Money], null: true
+  field :errors, resolver: Resolvers::Error
+
+  def resolve(item_id:)
+    item = Item.find(item_id)
+    result = PurchaseItem.new(item).call
+
+    if result.success?
+      {item: result.item, change: result.change.map(&:class), errors: []}
+    else
+      {item: nil, change: nil, errors: result.errors}
+    end
+  end
+end

--- a/db/migrate/20191020021520_create_items.rb
+++ b/db/migrate/20191020021520_create_items.rb
@@ -1,7 +1,8 @@
 class CreateItems < ActiveRecord::Migration[6.0]
   def change
     create_table :items do |t|
-      t.string :name
+      t.string :name, null: false
+      t.integer :cost, null: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,8 @@ ActiveRecord::Schema.define(version: 2019_10_20_193341) do
   enable_extension "plpgsql"
 
   create_table "items", force: :cascade do |t|
-    t.string "name"
+    t.string "name", null: false
+    t.integer "cost", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :item do
     name { Faker::Commerce.product_name }
+    cost { 10 }
   end
 end

--- a/spec/factories/money.rb
+++ b/spec/factories/money.rb
@@ -10,4 +10,6 @@ FactoryBot.define do
   end
 
   factory :quarter, parent: :money, class: Quarter
+  factory :dime, parent: :money, class: Dime
+  factory :nickel, parent: :money, class: Nickel
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -7,5 +7,7 @@ RSpec.describe Item, type: :model do
     end
 
     it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:cost) }
+    it { should validate_numericality_of(:cost).only_integer.is_greater_than(0) }
   end
 end

--- a/spec/models/make_change_spec.rb
+++ b/spec/models/make_change_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe MakeChange, type: :model do
+  describe "#call" do
+    it "makes correct change" do
+      result = described_class.new(available_money: [
+        build_stubbed(:quarter),
+        build_stubbed(:quarter),
+        build_stubbed(:dime),
+        build_stubbed(:dime),
+        build_stubbed(:dime),
+        build_stubbed(:nickel),
+        build_stubbed(:nickel),
+      ], due: 65).call
+
+
+      expect(result.success?).to be(true)
+      expect(result.change).to match([Quarter, Quarter, Dime, Nickel])
+    end
+
+    it "returns an empty array if no change is due" do
+      result = described_class.new(available_money: [
+        build_stubbed(:quarter),
+      ], due: 0).call
+
+      expect(result.success?).to be(true)
+      expect(result.change).to eq([])
+    end
+
+    it "fails if it does not have enough available_money to make change" do
+      result = described_class.new(available_money: [
+        build_stubbed(:quarter),
+      ], due: 65).call
+
+
+      expect(result.success?).to be(false)
+    end
+
+    it "fails if it cannot get the change to add up" do
+      result = described_class.new(available_money: [
+        build_stubbed(:quarter),
+        build_stubbed(:dime),
+      ], due: 30).call
+
+
+      expect(result.success?).to be(false)
+    end
+  end
+end

--- a/spec/models/purchase_item_spec.rb
+++ b/spec/models/purchase_item_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe PurchaseItem, type: :model do
+  describe "#call" do
+    it "returns the item and refunds the change on success" do
+      item = create(:item, cost: 10)
+      create(:quarter, :pending)
+      dime = create(:dime)
+      nickel = create(:nickel)
+
+      result = described_class.new(item).call
+
+      expect(result.success?).to be(true)
+      expect(result.item).to eq(item)
+      expect(result.change).to eq([dime, nickel])
+      expect(Dime.count).to eq(0)
+      expect(Nickel.count).to eq(0)
+    end
+
+    it "does not allow the purchase if there is not enough pending money" do
+      item = create(:item, cost: 35)
+      create(:quarter, :pending)
+      create(:dime)
+
+      result = described_class.new(item).call
+
+      expect(result.success?).to be(false)
+    end
+
+    it "does not allow the purchase if change cannot be made" do
+      item = create(:item, cost: 10)
+      create(:quarter, :pending)
+
+      result = described_class.new(item).call
+
+      expect(result.success?).to be(false)
+    end
+  end
+end

--- a/spec/models/result_spec.rb
+++ b/spec/models/result_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Result do
+  it "returns a successful result" do
+    result = described_class.success(works: true)
+
+    expect(result.success?).to eq(true)
+    expect(result.works).to eq(true)
+    expect(result.errors).to be_empty
+  end
+
+  it "returns a failure result" do
+    result = described_class.failure(["did not work"])
+
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(["did not work"])
+  end
+
+  it "accepts a string as an error" do
+    result = described_class.failure("did not work")
+
+    expect(result.success?).to eq(false)
+    expect(result.errors).to eq(["did not work"])
+  end
+end

--- a/spec/operations/create_item_mutation_spec.rb
+++ b/spec/operations/create_item_mutation_spec.rb
@@ -18,6 +18,7 @@ describe "Create Item Mutation API", :graphql do
       result = execute query, variables: {
         input: {
           name: "Snickers",
+          cost: 100
         },
       }
 

--- a/spec/operations/purchase_item_mutation_spec.rb
+++ b/spec/operations/purchase_item_mutation_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Purchase Item Mutation API", :graphql do
+  describe "purchaseItem" do
+    let(:query) do
+      <<~'GRAPHQL'
+        mutation($input: PurchaseItemInput!) {
+          purchaseItem(input: $input) {
+            item {
+              id
+            }
+            change
+          }
+        }
+      GRAPHQL
+    end
+
+    it "uses pending money to purchase an item and return the change" do
+      item = create(:item, cost: 25)
+      create_list(:dime, 3, :pending)
+      create(:nickel)
+
+      result = execute query, variables: {
+        input: {
+          itemId: item.id
+        },
+      }
+
+      result_data = result[:data][:purchaseItem]
+      expect(result_data[:item][:id]).to eq(item.id.to_s)
+      expect(result_data[:change]).to eq(["NICKEL"])
+      expect(Item.find_by(id: item.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Because:
- Purchasing an item is the key feature of a vending machine

This commit:
- Adds a new mutation which returns the item as well as an enum of change. The item as well as the returned change are deleted from our system.
- Adds new money types: `Dime` and `Nickel`
- Adds `cost` to `Item`
- Calculates change based on whats available and what is due
- Creates a new `Result` object used to communicate success or failure in our domain