### PR TITLE
Remove duplicates from items query

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,6 @@
 class Item < ApplicationRecord
   validates :name, presence: true
   validates :cost, presence: true, numericality: {greater_than: 0, only_integer: true}
+
+  scope :one_of_each, -> { select('DISTINCT ON (name, cost) *').all }
 end

--- a/app/operations/items_query.rb
+++ b/app/operations/items_query.rb
@@ -3,6 +3,6 @@ class ItemsQuery < Types::BaseResolver
   type Outputs::ItemType.connection_type, null: false
 
   def resolve
-    Item.all
+    Item.one_of_each
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of(:cost) }
     it { should validate_numericality_of(:cost).only_integer.is_greater_than(0) }
   end
+
+  describe ".one_of_each" do
+    it "returns only entries with distinct names and costs" do
+      create(:item, name: "Snickers", cost: 10)
+      create(:item, name: "Snickers", cost: 10)
+      create(:item, name: "Milky Way")
+
+      result = described_class.one_of_each
+
+      expect(result.to_a.count).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
Because:
- This vending machine is only going to list one of each item with the same name and cost

This commit:
- Adds a `one_of_each` scope that selects distinct on `name` and `cost`
- Uses this scope on the `ItemsQuery`