### PR TITLE
Deposit pending money during purchase

### DIFF
--- a/app/models/money.rb
+++ b/app/models/money.rb
@@ -11,6 +11,10 @@ class Money < ApplicationRecord
     pending.destroy_all
   end
 
+  def self.deposit
+    pending.update(pending: false)
+  end
+
   def value
     self.class::VALUE
   end

--- a/app/models/purchase_item.rb
+++ b/app/models/purchase_item.rb
@@ -12,6 +12,7 @@ class PurchaseItem
     ).call
 
     if result.success?
+      Money.deposit
       Result.success(
         item: item.delete,
         change: result.change.map { |change| change.destroy }

--- a/spec/models/money_spec.rb
+++ b/spec/models/money_spec.rb
@@ -44,4 +44,14 @@ RSpec.describe Money, type: :model do
       expect(result).to eq([first_pending_money, second_pending_money])
     end
   end
+
+  describe ".deposit" do
+    it "removes pending from all money" do
+      pending_money = create(:quarter, :pending)
+
+      result = described_class.deposit
+
+      expect(pending_money.reload).not_to be_pending
+    end
+  end
 end

--- a/spec/models/purchase_item_spec.rb
+++ b/spec/models/purchase_item_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PurchaseItem, type: :model do
   describe "#call" do
     it "returns the item and refunds the change on success" do
       item = create(:item, cost: 10)
-      create(:quarter, :pending)
+      pending_quarter = create(:quarter, :pending)
       dime = create(:dime)
       nickel = create(:nickel)
 
@@ -13,6 +13,7 @@ RSpec.describe PurchaseItem, type: :model do
       expect(result.success?).to be(true)
       expect(result.item).to eq(item)
       expect(result.change).to eq([dime, nickel])
+      expect(pending_quarter.reload).not_to be_pending
       expect(Dime.count).to eq(0)
       expect(Nickel.count).to eq(0)
     end


### PR DESCRIPTION
Because:
- If the purchase can succeed then we should take all of the pending money and put it in our bank

This commit:
- Adds a new class method to `Money` that sets pending to false for all pending money
- Calls this method if we are successfully able to make change, meaning that the purchase should go through