### PR TITLE
Return errors from inserting money

### DIFF
--- a/app/operations/create_item_mutation.rb
+++ b/app/operations/create_item_mutation.rb
@@ -13,7 +13,7 @@ class CreateItemMutation < Types::BaseMutation
     if item.save
       {item: item, errors: []}
     else
-      {item: nil, errors: result.errors}
+      {item: nil, errors: item.errors}
     end
   end
 end

--- a/app/operations/insert_money_mutation.rb
+++ b/app/operations/insert_money_mutation.rb
@@ -3,9 +3,16 @@ class InsertMoneyMutation < Types::BaseMutation
 
   argument :money, Types::Money, required: true
 
-  field :success, Boolean, null: true
+  field :money, Types::Money, null: true
+  field :errors, resolver: Resolvers::Error
 
   def resolve(money:)
-    { success: money.create }
+    money = money.new
+
+    if money.save
+      {money: money.class, errors: []}
+    else
+      {money: nil, errors: money.errors}
+    end
   end
 end

--- a/spec/operations/insert_money_mutation_spec.rb
+++ b/spec/operations/insert_money_mutation_spec.rb
@@ -6,7 +6,7 @@ describe "Insert Money Mutation API", :graphql do
       <<~'GRAPHQL'
         mutation($input: InsertMoneyInput!) {
           insertMoney(input: $input) {
-            success
+            money
           }
         }
       GRAPHQL
@@ -19,8 +19,8 @@ describe "Insert Money Mutation API", :graphql do
         },
       }
 
-      success_result = result[:data][:insertMoney][:success]
-      expect(success_result).to eq(true)
+      money_result = result[:data][:insertMoney][:money]
+      expect(money_result).to eq("QUARTER")
       expect(Quarter.count).to eq(1)
     end
   end


### PR DESCRIPTION
Because:
- The previous response was not giving the user any details if something went wrong
- This is also more consistent with the way we do errrors elsewhere

This commit:
- Adds the errors field to `insertMoney` mutation
- Returns the successfully created money
- Fixes a typo on `CreateItemMutation`